### PR TITLE
pst.py: replace slow dict check

### DIFF
--- a/pst.py
+++ b/pst.py
@@ -381,9 +381,9 @@ class NBD:
         
     def fetch_block(self, bid):
 
-        if bid.bid in self.bbt_entries.keys():
+        try:
             bbt_entry = self.bbt_entries[bid.bid]
-        else:
+        except KeyError:
             raise PSTException('Invalid BBTEntry: %s' % bid)
         offset = bbt_entry.BREF.ib
         data_size = bbt_entry.cb


### PR DESCRIPTION
Replace slow dict check which gets slower with larger PST files.
For a certain 5 GB PST file, this results in a several fold
performance improvement.